### PR TITLE
fix: turn off PostHog's web vitals collector

### DIFF
--- a/resources/js/posthog.ts
+++ b/resources/js/posthog.ts
@@ -41,6 +41,17 @@ const load = async (): Promise<PostHog | null> => {
         capture_pageview: false,
         capture_pageleave: true,
         cross_subdomain_cookie: true,
+        // PostHog lazily fetches Chrome's web-vitals library and it throws on
+        // every page load — `Cannot read properties of undefined (reading
+        // 'startTime')` inside reportAllChanges, from a requestIdleCallback.
+        // The script is loaded at runtime, so it shows up as an anonymous VM
+        // frame rather than anything in our bundle, and it only appears where
+        // PostHog is actually enabled. Nothing here reads web vitals, so the
+        // collector is switched off rather than left throwing in every
+        // visitor's console. Network timing is unrelated and stays on.
+        capture_performance: {
+            web_vitals: false,
+        },
         session_recording: {
             maskAllInputs: true,
             maskTextSelector: '.ph-no-capture',


### PR DESCRIPTION
Every page in production logs:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'startTime')
    at reportAllChanges (<anonymous>)
    ... requestIdleCallback
```

## Why it took two passes

`reportAllChanges` belongs to **Chrome's web-vitals library, which PostHog fetches at runtime** rather than shipping in the bundle. That explains the two things that kept misleading the diagnosis: the anonymous `VM###` frame (it is evaluated, not a file in our build) and the `requestIdleCallback` in the stack.

It also explains why it would not reproduce locally. With `POSTHOG_ENABLED=false` the SDK never loads; with a fake API key it loads but never fetches the remote script. **The error only exists where PostHog is genuinely enabled** — production.

The earlier dynamic-import change was still worth having (the SDK no longer ships to visitors who have analytics off, and it left the main bundle), but it could not have fixed this: production has PostHog enabled, so the SDK loads legitimately and brings the faulty collector with it.

## The fix

`capture_performance.web_vitals` is the switch for precisely that collector — the type docs describe it as *"Use chrome's web vitals library to wrap fetch and capture web vitals"*.

Nothing in Lua reads web vitals, so it is turned off rather than left throwing in every visitor's console. `network_timing` is a separate flag under the same key, belongs to session replay, and is untouched.

## Verification

Typecheck, lint, build and **544 tests** pass. The behavioural check has to happen on deploy: the console error should be gone, and PostHog events, session replay and pageviews should keep arriving as before.